### PR TITLE
1. generate_cvd_gallery() — now produces all 8 CVD variants from defi…

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,8 +95,36 @@ def image_to_bytes(img: Image.Image, fmt: str = 'PNG') -> bytes:
     return buf.getvalue()
 
 def generate_cvd_gallery(original: Image.Image) -> list[tuple[Image.Image, str]]:
-    """Alias for generate_cvd_grid."""
-    return generate_cvd_grid(original)
+    """Generate all 8 CVD variant images from deficiency_config.
+
+    Produces one image per CVD type in deficiency_config.
+    """
+    gallery = []
+    for cvd_name, cfg in deficiency_config.items():
+        sim = cfg['simulator']
+        deficiency = cfg['deficiency']
+        severity = cfg['severity']
+        simulated = simulate_cvd(original, sim, deficiency, severity)
+        # Format label: "Protanopia (red-blind)", "Deuteranomaly (green-weak)", etc.
+        label = _cvd_name_to_label(cvd_name)
+        gallery.append((simulated, label))
+    return gallery
+
+
+def _cvd_name_to_label(cvd_name: str) -> str:
+    """Map deficiency_config key to human-readable label."""
+    labels = {
+        'protanopia': 'Protanopia (red-blind)',
+        'severe_protanopia': 'Severe Protanopia (red-blind)',
+        'deuteranopia': 'Deuteranopia (green-blind)',
+        'severe_deuteranopia': 'Severe Deuteranopia (green-blind)',
+        'tritanopia': 'Tritanopia (blue-blind)',
+        'protanomaly': 'Protanomaly (red-weak)',
+        'deuteranomaly': 'Deuteranomaly (green-weak)',
+        'tritanomaly': 'Tritanomaly (blue-weak)',
+    }
+    return labels.get(cvd_name, cvd_name)
+
 
 def generate_cvd_grid(original: Image.Image) -> list[tuple[Image.Image, str]]:
     """Generate the 2x2 CVD comparison grid.
@@ -180,12 +208,53 @@ _VLM_CVD_PROMPTS = {
         "and contrast problems specific to your condition."
     ),
     "Tritanopia (blue-blind)": (
-        "You have tritanopia (blue-blind CVD). Analyze this page as it appears to you. "
-        "Focus on WCAG 2.1 compliance issues that affect a tritanope: "
-        "blue-yellow color confusion, information conveyed solely by blue, "
-        "and contrast problems specific to your condition."
-    ),
-}
+            "You have tritanopia (blue-blind CVD). Analyze this page as it appears to you. "
+            "Focus on WCAG 2.1 compliance issues that affect a tritanope: "
+            "blue-yellow color confusion, information conveyed solely by blue, "
+            "and contrast problems specific to your condition."
+        ),
+        "Severe Protanopia (red-blind)": (
+            "You have severe protanopia (complete red-blindness, severity 1.0). "
+            "Analyze this page as it appears to you. "
+            "Focus on WCAG 2.1 compliance issues for a protanope with no functional red cones: "
+            "red-green color confusion, information conveyed solely by red, "
+            "and contrast problems specific to your condition."
+        ),
+        "Severe Deuteranopia (green-blind)": (
+            "You have severe deuteranopia (complete green-blindness, severity 1.0). "
+            "Analyze this page as it appears to you. "
+            "Focus on WCAG 2.1 compliance issues for a deuteranope with no functional green cones: "
+            "green-red color confusion, information conveyed solely by green, "
+            "and contrast problems specific to your condition."
+        ),
+        "Protanomaly (red-weak)": (
+            "You have protanomaly (red-weak CVD, partial protanopia). "
+            "Colors appear less bright and red/orange hues are shifted. "
+            "Analyze this page as it appears to you. "
+            "Focus on WCAG 2.1 compliance issues that affect someone with reduced red sensitivity: "
+            "red-green color confusion (milder than protanopia), "
+            "information conveyed solely by red, "
+            "and contrast problems specific to your condition."
+        ),
+        "Deuteranomaly (green-weak)": (
+            "You have deuteranomaly (green-weak CVD, the most common form of colorblindness). "
+            "Colors appear less bright and green/yellow hues are shifted. "
+            "Analyze this page as it appears to you. "
+            "Focus on WCAG 2.1 compliance issues that affect someone with reduced green sensitivity: "
+            "green-red color confusion (milder than deuteranopia), "
+            "information conveyed solely by green, "
+            "and contrast problems specific to your condition."
+        ),
+        "Tritanomaly (blue-weak)": (
+            "You have tritanomaly (blue-weak CVD, partial tritanopia). "
+            "Colors appear shifted and blue/violet hues are less distinct. "
+            "Analyze this page as it appears to you. "
+            "Focus on WCAG 2.1 compliance issues that affect someone with reduced blue sensitivity: "
+            "blue-yellow color confusion (milder than tritanopia), "
+            "information conveyed solely by blue, "
+            "and contrast problems specific to your condition."
+        ),
+    }
 
 _ACCESSIBILITY_SYSTEM_PROMPT = (
     "Output a JSON object with this structure:\n"
@@ -303,6 +372,32 @@ def analyze_all_perspectives(cvd_grid: list) -> dict:
 _theme_css = """
 :root { --color-primary: #1E88E5; }
 .gradio-container { font-family: 'Inter', Arial, sans-serif; }
+/* Gallery: fixed 4:3 aspect ratio per thumbnail, centered crop */
+.gallery .grid-container .image-item,
+.gallery .grid-container [data-testid="gallery"] .image-container {
+    aspect-ratio: 4 / 3 !important;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.gallery img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover !important;
+    object-position: center center;
+}
+/* Caption labels: truncate long labels to 1 line */
+.thumbnail-item .caption-label {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+    text-align: center;
+    display: block;
+}
 """
 
 _gradio_version = tuple(int(x) for x in gr.__version__.split('.')[:2])
@@ -341,45 +436,52 @@ with gr.Blocks(
         submit_btn = gr.Button('Analyze', variant='primary', scale=0)
 
     with gr.Row():
-        cvd_grid = gr.Gallery(
-            label='Color-Vision Comparison (2x2 grid)',
-            columns=2,
-            rows=2,
-            object_fit='contain',
-            height=600,
-        )
+            cvd_grid = gr.Gallery(
+                label='Color-Vision Simulation Gallery (8 CVD variants)',
+                columns=4,
+                object_fit='cover',
+                height=500,
+            )
+            report_output = gr.Markdown(label='Accessibility Report')
 
-    report_output = gr.Markdown(label='Accessibility Report')
+            # State to hold the current CVD grid for VLM analysis
+            current_cvd_grid = gr.State([])
 
-    def run_analysis(file_obj):
-        """File upload mode -- receives screenshot bytes, returns CVD grid + report."""
-        if file_obj is None:
-            return [], 'Please upload a screenshot first.'
+            def handle_file_upload(file_obj):
+                """On file upload: generate gallery images immediately (no VLM)."""
+                if file_obj is None:
+                    return [], gr.update()
+                image_bytes = file_obj if isinstance(file_obj, bytes) else file_obj.read()
+                try:
+                    original = Image.open(io.BytesIO(image_bytes)).convert('RGB')
+                except Exception as e:
+                    return [], f'Could not open image: {e}'
+                gallery = generate_cvd_gallery(original)
+                return gallery, gallery  # Return gallery for display and state
 
-        image_bytes = file_obj if isinstance(file_obj, bytes) else file_obj.read()
+            def run_vlm_analysis(cvd_grid_state):
+                """On Analyze click: run VLM on the pre-generated CVD grid."""
+                if not cvd_grid_state:
+                    return 'Please upload a screenshot first.'
+                try:
+                    vlm_result = analyze_all_perspectives(cvd_grid_state)
+                except Exception as e:
+                    vlm_result = {'error': str(e), 'findings': [], 'passes': False}
+                return format_wcag_report(vlm_result)
 
-        try:
-            original = Image.open(io.BytesIO(image_bytes)).convert('RGB')
-        except Exception as e:
-            return [], f'Could not open image: {e}'
+            # File upload triggers gallery generation immediately
+            file_input.change(
+                fn=handle_file_upload,
+                inputs=file_input,
+                outputs=[cvd_grid, current_cvd_grid],
+            )
 
-        grid = generate_cvd_grid(original)
-
-        # Send ALL CVD perspectives to the VLM endpoint
-        # Each variant gets a role-specific prompt (Normal, Protanopia, Deuteranopia, Tritanopia)
-        try:
-            vlm_result = analyze_all_perspectives(grid)
-        except Exception as e:
-            vlm_result = {'error': str(e), 'findings': [], 'passes': False}
-
-        report_md = format_wcag_report(vlm_result)
-        return grid, report_md
-
-    submit_btn.click(
-        fn=run_analysis,
-        inputs=file_input,
-        outputs=[cvd_grid, report_output],
-    )
+            # Analyze button triggers VLM only
+            submit_btn.click(
+                fn=run_vlm_analysis,
+                inputs=current_cvd_grid,
+                outputs=report_output,
+            )
 
 
 if __name__ == '__main__':

--- a/tests/test_app_space.py
+++ b/tests/test_app_space.py
@@ -158,5 +158,100 @@ class TestDeficiencyConfig:
             assert 'severity' in cfg, f"{name} missing severity"
 
     def test_severity_values_are_floats(self):
-        for name, cfg in app_module.deficiency_config.items():
-            assert isinstance(cfg['severity'], float), f"{name} severity not float"
+            for name, cfg in app_module.deficiency_config.items():
+                assert isinstance(cfg['severity'], float), f"{name} severity not float"
+
+
+    # ── Full 8-Type CVD Gallery Tests ─────────────────────────────────────────────
+
+    class TestFullCVDGallery:
+        """
+        Gallery must show all 8 CVD variants from deficiency_config, not just 4.
+        File upload triggers gallery generation; Analyze button triggers VLM only.
+        """
+
+        def test_generate_cvd_gallery_returns_8_items(self, img_factory):
+            """Gallery should produce one image per CVD type (8 total)."""
+            img = img_factory(200, 200)
+            gallery = app_module.generate_cvd_gallery(img)
+            assert len(gallery) == 8, f"Expected 8 CVD variants, got {len(gallery)}"
+
+        def test_gallery_has_8_unique_labels(self, img_factory):
+            """Each of the 8 CVD types should appear in the gallery."""
+            img = img_factory(200, 200)
+            gallery = app_module.generate_cvd_gallery(img)
+            labels = [label for _, label in gallery]
+            assert len(labels) == 8, f"Expected 8 labels, got {len(labels)}"
+            # All labels should be unique (no duplicates)
+            assert len(set(labels)) == 8, f"Labels not unique: {labels}"
+
+        def test_gallery_covers_all_deficiency_types(self, img_factory):
+                    """Gallery should include all 8 types from deficiency_config."""
+                    img = img_factory(200, 200)
+                    gallery = app_module.generate_cvd_gallery(img)
+                    gallery_labels = [label for _, label in gallery]
+                    expected_types = list(app_module.deficiency_config.keys())
+                    for expected in expected_types:
+                        # Split by underscore so 'severe_protanopia' → ['severe','protanopia']
+                        # then check all parts appear (case-insensitive) in the label
+                        parts = expected.lower().split('_')
+                        found = all(any(part in label.lower() for label in gallery_labels)
+                                    for part in parts)
+                        assert found, f"CVD type '{expected}' not found in gallery labels: {gallery_labels}"
+
+
+    # ── Event Handler Separation Tests ────────────────────────────────────────────
+
+    class TestEventHandlerSeparation:
+        """
+        File upload triggers gallery generation.
+        Analyze button only triggers VLM endpoint.
+        These should be separate event handlers.
+        """
+
+        def test_app_has_handle_file_upload_function(self):
+            """App must have a function to handle file upload events (for gallery generation)."""
+            assert hasattr(app_module, 'handle_file_upload'), \
+                "App must have handle_file_upload() function for file change event"
+
+        def test_app_has_run_vlm_analysis_function(self):
+            """App must have a function to handle Analyze button click (VLM only)."""
+            assert hasattr(app_module, 'run_vlm_analysis'), \
+                "App must have run_vlm_analysis() function for analyze button"
+
+        def test_handle_file_upload_does_not_call_vlm(self):
+            """File upload handler should generate gallery only, not call VLM."""
+            import inspect
+            assert hasattr(app_module, 'handle_file_upload'), "Missing handle_file_upload"
+            source = inspect.getsource(app_module.handle_file_upload)
+            # Should NOT call analyze_all_perspectives or _call_minicpm_endpoint
+            assert 'analyze_all_perspectives' not in source, \
+                "handle_file_upload should not call VLM (analyze_all_perspectives)"
+            assert '_call_minicpm_endpoint' not in source, \
+                "handle_file_upload should not call VLM directly"
+
+        def test_run_vlm_analysis_calls_vlm_endpoint(self):
+            """Analyze handler should call VLM endpoint."""
+            import inspect
+            assert hasattr(app_module, 'run_vlm_analysis'), "Missing run_vlm_analysis"
+            source = inspect.getsource(app_module.run_vlm_analysis)
+            assert 'analyze_all_perspectives' in source or '_call_minicpm_endpoint' in source, \
+                "run_vlm_analysis should call VLM endpoint"
+
+
+    # ── Gallery Layout Configuration Tests ────────────────────────────────────────
+
+    class TestGalleryLayout:
+        """
+        Gallery should display in a sensible grid layout (2x4) for 8 images.
+        """
+
+        def test_gallery_columns_and_rows_configured(self):
+            """Gradio Gallery should be configured with columns=4, rows=2 for 8 images."""
+            app_source = pathlib.Path(__file__).resolve().parent.parent / 'app.py'
+            source = app_source.read_text()
+            # Find Gallery component definition
+            assert 'gr.Gallery(' in source, "No gr.Gallery found in app.py"
+            # Should have columns=4 (showing 4 per row for 8 images = 2 rows)
+            assert 'columns=4' in source or 'columns = 4' in source, \
+                "Gallery should use columns=4 for 2x4 layout of 8 images"


### PR DESCRIPTION
…ciency_config instead of calling generate_cvd_grid() (which remains for backward compat)

    2. _cvd_name_to_label() — new helper mapping config keys to human-readable labels (e.g. protanomaly → Protanomaly (red-weak))
    3. File upload change handler (handle_file_upload) — generates gallery immediately on file upload; no VLM call
    4. Analyze button handler (run_vlm_analysis) — calls VLM only via analyze_all_perspectives() using stored state
    5. gr.State([]) — current_cvd_grid holds the pre-generated gallery between upload and analysis
    6. Gallery updated — columns=4, object_fit='cover', height=500, label says "8 CVD variants"
    7. _VLM_CVD_PROMPTS — expanded with prompts for all 8 labels (Severe Protanopia, Severe Deuteranopia, Protanomaly, Deuteranomaly, Tritanomaly)
    8. _theme_css — added 4:3 aspect-ratio, object-fit: cover, centered crop, and caption truncation styles

    tests/test_app_space.py
    - Added TestFullCVDGallery (3 tests): 8 items, unique labels, all deficiency types covered
    - Added TestEventHandlerSeparation (4 tests): handle_file_upload / run_vlm_analysis exist, don't call VLM / do call VLM respectively
    - Added TestGalleryLayout (1 test): columns=4 in source

    To run: uv run app.py then upload a screenshot — gallery loads instantly, Analyze triggers VLM.