### PR TITLE
fix: consolidate Modal web endpoint inside GPU class

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,16 @@ Test steps: upload `tests/fixtures/UR.webp` → click **Analyze** → verify the
 
 ## Sponsor Prize Eligibility
 
-| Sponsor | Prize | Status |
-|---------|-------|--------|
-| HuggingFace | $15,000 | ✅ Eligible — top project |
-| OpenBMB (MiniCPM-V 4.6 swap) | $10,000 | 🔲 One-line model swap |
-| Modal | $250 credits | ✅ Already deployed |
-| Cohere | Prize support | ✅ Using aya-vision-32b |
-| NVIDIA RTX 5080 ×2 | GPUs | ⚠️ Confirm Nemotron req |
+| Sponsor                 | Prize | Status                   |
+|-------------------------|-------|--------------------------|
+| HuggingFace             | $15,000 | ✅ Eligible — top project |
+| OpenBMB (MiniCPM-V 4.6) | $10,000 | ✅ Already deployed       |
+| Modal                   | $250 credits | ✅ Already deployed       |
 
-**Required:** Demo video + social media post. See `docs/EVALUATION.md` for full matrix and bonus quests.
+**Required:** 
+- ✅ Gradio App: (Space)[https://huggingface.co/spaces/build-small-hackathon/color-ux-access]
+- ✅ Demo video: (YouTube)[https://www.youtube.com/watch?v=ynwuZNcqRtY] 
+- ✅ Social Media Post: [LinkedIn](https://www.linkedin.com/posts/salgadev_build-small-hackathon-build-small-hackathon-share-7472421346992476161--5sG/)
 
 ---
 

--- a/modal_deploy_minicpm.py
+++ b/modal_deploy_minicpm.py
@@ -15,8 +15,8 @@ MODEL_ID = "openbmb/MiniCPM-V-4.6"
 
 @app.cls(
     gpu="A100",
-    scaledown_window=300,
-    timeout=600,
+    scaledown_window=600,
+    timeout=900,
     image=vllm_image,
     secrets=[modal.Secret.from_name("hf-token-minicpm")],
 )
@@ -31,7 +31,7 @@ class MiniCPMVLLM:
         if hf_token:
             print("HF_TOKEN is set")
         else:
-            print("HF_TOKEN is NOT set")
+            print("HF_TOKEN: NOT set")
 
         self.llm = LLM(
             model=MODEL_ID,
@@ -46,10 +46,10 @@ class MiniCPMVLLM:
             max_tokens=2048,
             top_p=0.95,
         )
+        print("MiniCPM-V engine ready.")
 
     @modal.method()
     async def generate(self, prompt: str, image_base64: str = None) -> str:
-        # Build message content
         content = []
         if image_base64:
             content.append({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_base64}"}})
@@ -68,12 +68,10 @@ class MiniCPMVLLM:
         )
         return outputs[0].outputs[0].text
 
-
-@app.function(image=vllm_image)
-@modal.fastapi_endpoint(method="POST")
-async def inference(request: dict):
-    prompt = request.get("prompt", "")
-    image_b64 = request.get("image_base64")
-    infer = MiniCPMVLLM()
-    result = infer.generate.remote(prompt, image_b64)
-    return {"response": result}
+    @modal.fastapi_endpoint(method="POST")
+    async def inference(self, request: dict):
+        """Direct GPU endpoint — no proxy, no separate web function."""
+        prompt = request.get("prompt", "")
+        image_b64 = request.get("image_base64")
+        result = await self.generate.local(prompt, image_b64)
+        return {"response": result}


### PR DESCRIPTION
The inference endpoint was a separate CPU function calling the GPU class via .remote(), causing dual-timeout on cold starts (~77s warmup exceeded HTTP gateway timeout).

**Fix**: Moved @modal.fastapi_endpoint inside MiniCPMVLLM class — HTTP goes directly to GPU container.
- scaledown_window: 300→600
- timeout: 600→900
- Uses self.generate.local() instead of MiniCPMVLLM.generate.remote()
- New endpoint URL auto-generated by Modal

**Tested**: End-to-end confirmed working with WCAG reports from all CVD perspectives.